### PR TITLE
Allow loading data from remote URL's

### DIFF
--- a/src/components/FamilyNode/FamilyNode.tsx
+++ b/src/components/FamilyNode/FamilyNode.tsx
@@ -13,7 +13,7 @@ interface Props {
 export default React.memo<Props>(
   function FamilyNode({ node, isRoot, onSubClick, style }) {
     return (
-      <div className={styles.root} style={style}>
+      <div className={styles.root} style={style} title={node.id}>
         <div
           className={classNames(
             styles.inner,


### PR DESCRIPTION
Adding the capability to load JSON family information from remote
sources. This will let us review and play with examples created by
external people or for debugging purposes.

For example, you can load this URL that I extracted from #3 issue:

`https://gist.githubusercontent.com/fcsonline/64b1149cf544237fbc10a786de871e18/raw/cf658d5199aaf51cbbdc0d83599f60b9dbe05872/tree.sample.json`

Screenshot:

![image](https://user-images.githubusercontent.com/135988/115971926-ab4ccf00-a54b-11eb-9de2-8f21fa3f0e6e.png)


